### PR TITLE
Add one-way mirror sync commands for device-local reorganization

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,22 @@ You can get additional information about a specific command by calling `dptrp1 h
 
 Note that the root path for DPT-RP1 is always `Document/`, which is misleadingly displayed as "System Storage" on the device. To download a document called _file.pdf_ from a folder called _Articles_ of the DPT-RP1, the correct command is `dptrp1 download Document/Articles/file.pdf`.
 
+#### One-way mirror commands (`sync-from-device` / `sync-to-device`)
+The `sync` command tries to be clever about merging changes on both sides, which is helpful when you only add or edit files but gets confused when you _reorganize_ (a locally moved file looks indistinguishable from "delete here + create there"). For that workflow, two one-way mirror commands are provided:
+
+* `dptrp1 sync-from-device <local_path> [<remote_path>]` — makes the local folder match the device. Downloads new/changed PDFs and **deletes** local PDFs and empty folders that are not on the device.
+* `dptrp1 sync-to-device <local_path> [<remote_path>]` — makes the device match the local folder. Uploads new/changed PDFs and **deletes** PDFs and empty folders on the device that are not present locally.
+
+Both commands print the planned changes and ask for confirmation before touching any file. Type `?` at the prompt to list every affected file. Pass the top-level `-y` flag to skip the prompt (e.g. `dptrp1 -y sync-to-device ...`). Unlike `sync`, these commands do not use a `.sync` checkpoint file; they compare modification times directly.
+
+A typical reorganize workflow:
+
+```
+dptrp1 sync-from-device ~/Papers Document/Papers   # pull annotations
+# move files around in ~/Papers on your computer
+dptrp1 sync-to-device   ~/Papers Document/Papers   # push the new layout
+```
+
 ### Registering the DPT-RP1
 The DPT-RP1 uses SSL encryption to communicate with the computer.  This requires registering the DPT-RP1 with the computer, which results in two pieces of information, the client ID and the private key. If you have used Sony's Digital Paper App on the same computer, the utility will automatically try to use the existing credentials. If you do not have the Digital Paper App, use the _register_ command.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ pip3 install dpt-rp1-py
 
 Installing the package also installs the command line utilities `dptrp1` and `dptmount`. To install the library from the sources, clone this repository, then run `python3 setup.py install` or `pip3 install .` from the root directory. To install as a developer use `python3 setup.py develop` (see [the setuptools docs](http://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode)) and work on the source as usual.
 
+### Installing from source with pipx (recommended on Debian/Ubuntu)
+On modern Debian/Ubuntu (and other distributions that follow [PEP 668](https://peps.python.org/pep-0668/)) a plain `pip3 install .` into the system Python is refused with an `externally-managed-environment` error. The cleanest way to get the CLI on your `PATH` is [pipx](https://pipx.pypa.io/), which puts the package in its own isolated virtual environment:
+
+```
+sudo apt install pipx      # if you don't already have it
+pipx install .             # run from the repo root
+```
+
+This installs the `dptrp1` and `dptmount` commands globally under `~/.local/bin`.
+
+**Workaround for Python 3.12+:** the transitive dependency `httpsig` still imports `pkg_resources`, which setuptools 81 (mid-2025) removed. If `dptrp1 --help` fails with `ModuleNotFoundError: No module named 'pkg_resources'`, inject an older setuptools into the pipx venv:
+
+```
+pipx inject dpt-rp1-py 'setuptools<81'
+```
+
+Do the injection **after** the last `pipx install` — a subsequent `pipx install --force` rebuilds the venv and wipes any injected packages.
+
 ## Using the command line utility
 The command line utility requires a connection to the reader via WiFi, Bluetooth, or USB. The USB connection works on Windows and MacOS but may not work on a Linux machine.
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,14 @@ The `sync` command tries to be clever about merging changes on both sides, which
 * `dptrp1 sync-from-device <local_path> [<remote_path>]` — makes the local folder match the device. Downloads new/changed PDFs and **deletes** local PDFs and empty folders that are not on the device.
 * `dptrp1 sync-to-device <local_path> [<remote_path>]` — makes the device match the local folder. Uploads new/changed PDFs and **deletes** PDFs and empty folders on the device that are not present locally.
 
-Both commands print the planned changes and ask for confirmation before touching any file. Type `?` at the prompt to list every affected file. Pass the top-level `-y` flag to skip the prompt (e.g. `dptrp1 -y sync-to-device ...`). Unlike `sync`, these commands do not use a `.sync` checkpoint file; they compare modification times directly.
+Both commands print the planned changes and ask for confirmation before touching any file. At the prompt you can answer:
+
+* `y` — apply every change
+* `n` — abort without doing anything
+* `d` — apply the transfers (downloads/uploads and folder creation) but **skip the deletes**, so files that only exist on one side stay put. Use this for an additive pull/push, e.g. when you added PDFs on the device that you want to fetch without losing the local files you've been reorganizing.
+* `?` — list every affected file, then ask again
+
+Pass the top-level `-y` flag to skip the prompt (e.g. `dptrp1 -y sync-to-device ...`); `-y` always answers `y` (the full mirror). Unlike `sync`, these commands do not use a `.sync` checkpoint file; they compare modification times directly.
 
 A typical reorganize workflow:
 

--- a/dptrp1/cli/dptrp1.py
+++ b/dptrp1/cli/dptrp1.py
@@ -142,6 +142,39 @@ def do_sync(d, local_path, remote_path="Document"):
     d.sync(local_path, remote_path)
 
 
+def do_sync_from_device(d, local_path, remote_path="Document"):
+    """
+    One-way mirror: make the local folder match the device.
+
+    Downloads new or changed PDFs from the device and DELETES local PDFs and
+    empty folders that are not present on the device. Useful when the device
+    is the source of truth (for example, after annotating on the device).
+
+    The planned changes are printed and confirmation is requested before
+    anything happens. Pass -y (top-level) to skip the prompt.
+
+    Example: dptrp1 sync-from-device ~/Dropbox/Papers Document/Papers
+    """
+    d.force_sync_to_local(local_path, remote_path)
+
+
+def do_sync_to_device(d, local_path, remote_path="Document"):
+    """
+    One-way mirror: make the device match the local folder.
+
+    Uploads new or changed PDFs to the device and DELETES PDFs and empty
+    folders on the device that are not present locally. Useful when your
+    local folder is the source of truth (for example, after re-organizing
+    files locally).
+
+    The planned changes are printed and confirmation is requested before
+    anything happens. Pass -y (top-level) to skip the prompt.
+
+    Example: dptrp1 sync-to-device ~/Dropbox/Papers Document/Papers
+    """
+    d.force_sync_to_device(local_path, remote_path)
+
+
 def do_new_folder(d, remote_path):
     d.new_folder(add_prefix(remote_path))
 
@@ -286,6 +319,8 @@ commands = {
     "register": do_register,
     "update-firmware": do_update_firmware,
     "sync": do_sync,
+    "sync-from-device": do_sync_from_device,
+    "sync-to-device": do_sync_to_device,
     "help": do_help,
     "display-document": do_display_document,
     "get-configuration": do_get_config,

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -997,17 +997,23 @@ class DigitalPaper:
     def _confirm_mirror(self, actions):
         """
         Print a summary of the planned actions and ask the user to confirm.
-        Returns True to proceed, False to abort. Returns None if there is
-        nothing to do.
+        Each action is a tuple (items, description, destructive) where
+        `destructive` is True for delete-style actions.
+
+        Returns True to proceed, False to abort, or None if there is
+        nothing to do. If the user answers `d` (skip deletes), all
+        destructive action lists are emptied in place before True is
+        returned, so the caller's own lists (which are the same objects)
+        become empty and their loops skip.
         """
-        total = sum(len(items) for items, _ in actions)
+        total = sum(len(items) for items, _, _ in actions)
         if total == 0:
             print("Already in sync. Nothing to do.")
             return None
         preview = 5
         print("")
         print("Planned changes:")
-        for items, description in actions:
+        for items, description, _ in actions:
             if not items:
                 continue
             print(f"  {len(items):4d} {description}:")
@@ -1018,14 +1024,36 @@ class DigitalPaper:
         print("")
         if self.assume_yes:
             return True
+
+        has_destructive = any(
+            destructive and items for items, _, destructive in actions
+        )
+        if has_destructive:
+            print("  y   yes, apply every change above")
+            print("  n   no, abort without doing anything")
+            print("  d   apply transfers only, skip the deletes")
+            print("  ?   list every affected file, then ask again")
+            prompt = "Proceed (y/n/d/?)? "
+        else:
+            print("  y   yes, apply every change above")
+            print("  n   no, abort without doing anything")
+            print("  ?   list every affected file, then ask again")
+            prompt = "Proceed (y/n/?)? "
+
         while True:
-            confirm = input("Proceed (y/n/?)? ").strip().lower()
+            confirm = input(prompt).strip().lower()
             if confirm in ("y", "yes"):
                 return True
             if confirm in ("n", "no", ""):
                 return False
+            if has_destructive and confirm in ("d", "delete-skip", "no-delete"):
+                for items, _, destructive in actions:
+                    if destructive:
+                        items.clear()
+                print("Skipping deletes; will only transfer files.")
+                return True
             if confirm in ("?", "list", "l"):
-                for items, description in actions:
+                for items, description, _ in actions:
                     if items:
                         print("")
                         print(f"The following will be {description}:")
@@ -1041,7 +1069,9 @@ class DigitalPaper:
         the device. Only .pdf files are considered, matching `sync`.
 
         A plan is printed and the user is asked to confirm before any
-        change is made, unless -y was passed on the command line.
+        change is made, unless -y was passed on the command line. At the
+        prompt, answering `d` proceeds with the transfers but skips the
+        delete actions (additive pull).
         """
         self.set_datetime()
         os.makedirs(local_folder, exist_ok=True)
@@ -1073,17 +1103,17 @@ class DigitalPaper:
         )
 
         actions = [
-            (to_delete_local, "files DELETED locally"),
-            (folders_to_delete_local, "folders DELETED locally"),
-            (folders_to_create_local, "folders CREATED locally"),
-            (to_download, "files DOWNLOADED from device"),
+            (to_delete_local, "files DELETED locally", True),
+            (folders_to_delete_local, "folders DELETED locally", True),
+            (folders_to_create_local, "folders CREATED locally", False),
+            (to_download, "files DOWNLOADED from device", False),
         ]
         proceed = self._confirm_mirror(actions)
         if not proceed:
             return
 
         progress = tqdm(
-            total=sum(len(items) for items, _ in actions),
+            total=sum(len(items) for items, _, _ in actions),
             desc="Mirroring",
             unit="items",
         )
@@ -1137,7 +1167,9 @@ class DigitalPaper:
         `sync`.
 
         A plan is printed and the user is asked to confirm before any
-        change is made, unless -y was passed on the command line.
+        change is made, unless -y was passed on the command line. At the
+        prompt, answering `d` proceeds with the transfers but skips the
+        delete actions (additive push).
         """
         self.set_datetime()
         self.new_folder(remote_folder)
@@ -1168,17 +1200,17 @@ class DigitalPaper:
         )
 
         actions = [
-            (to_delete_remote, "files DELETED on device"),
-            (folders_to_delete_remote, "folders DELETED on device"),
-            (folders_to_create_remote, "folders CREATED on device"),
-            (to_upload, "files UPLOADED to device"),
+            (to_delete_remote, "files DELETED on device", True),
+            (folders_to_delete_remote, "folders DELETED on device", True),
+            (folders_to_create_remote, "folders CREATED on device", False),
+            (to_upload, "files UPLOADED to device", False),
         ]
         proceed = self._confirm_mirror(actions)
         if not proceed:
             return
 
         progress = tqdm(
-            total=sum(len(items) for items, _ in actions),
+            total=sum(len(items) for items, _, _ in actions),
             desc="Mirroring",
             unit="items",
         )

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 from glob import glob
 from urllib.parse import quote_plus
 from dptrp1.pyDH import DiffieHellman
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from pbkdf2 import PBKDF2
 from Crypto.Hash import SHA256
 from Crypto.Hash.HMAC import HMAC
@@ -943,6 +943,299 @@ class DigitalPaper:
         checkpoint_file = os.path.join(local_folder, ".sync")
         with open(checkpoint_file, "wb") as f:
             pickle.dump(doclist, f)
+
+    def _mirror_inventory(self, local_folder, remote_folder):
+        """
+        Build normalized inventories of PDF files and folders under
+        remote_folder on the device and under local_folder on disk.
+
+        Returns (remote_files, remote_folders, local_files, local_folders)
+        where the *_files entries map remote-style path -> UTC datetime and
+        the *_folders entries are sets of remote-style paths.
+        """
+        def normalize_path(path):
+            return unicodedata.normalize("NFC", path).replace(os.sep, "/")
+
+        remote_info = self.traverse_folder(
+            remote_folder, fields=["entry_path", "modified_date", "entry_type"]
+        )
+        remote_files = {}
+        remote_folders = set()
+        for f in remote_info:
+            path = normalize_path(f["entry_path"])
+            if not path.startswith(remote_folder):
+                continue
+            if f["entry_type"] == "document":
+                if not path.lower().endswith(".pdf"):
+                    continue
+                remote_files[path] = datetime.strptime(
+                    f["modified_date"], "%Y-%m-%dT%H:%M:%SZ"
+                )
+            elif f["entry_type"] == "folder":
+                remote_folders.add(path)
+
+        local_files = {}
+        local_folders = set()
+
+        def walk(path):
+            rel = Path(path).relative_to(local_folder)
+            rp = normalize_path((Path(remote_folder) / rel).as_posix())
+            local_folders.add(rp)
+            for entry in os.scandir(path):
+                if entry.is_dir():
+                    walk(entry.path)
+                elif entry.name.lower().endswith(".pdf") and not entry.name.startswith("."):
+                    erel = Path(entry.path).relative_to(local_folder)
+                    erp = normalize_path((Path(remote_folder) / erel).as_posix())
+                    local_files[erp] = datetime.utcfromtimestamp(
+                        entry.stat().st_mtime
+                    )
+
+        walk(local_folder)
+        return remote_files, remote_folders, local_files, local_folders
+
+    def _confirm_mirror(self, actions):
+        """
+        Print a summary of the planned actions and ask the user to confirm.
+        Returns True to proceed, False to abort. Returns None if there is
+        nothing to do.
+        """
+        total = sum(len(items) for items, _ in actions)
+        if total == 0:
+            print("Already in sync. Nothing to do.")
+            return None
+        print("")
+        print("Planned changes:")
+        for items, description in actions:
+            if items:
+                print(f"  {len(items):4d} {description}")
+        print("")
+        if self.assume_yes:
+            return True
+        while True:
+            confirm = input("Proceed (y/n/?)? ").strip().lower()
+            if confirm in ("y", "yes"):
+                return True
+            if confirm in ("n", "no", ""):
+                return False
+            if confirm in ("?", "list", "l"):
+                for items, description in actions:
+                    if items:
+                        print("")
+                        print(f"The following will be {description}:")
+                        print("\t" + "\n\t".join(items))
+                        print("")
+
+    def force_sync_to_local(self, local_folder, remote_folder="Document"):
+        """
+        One-way mirror: make the local folder match the device.
+
+        Downloads files whose modification time differs from the local copy
+        and DELETES local files and (empty) folders that do not exist on
+        the device. Only .pdf files are considered, matching `sync`.
+
+        A plan is printed and the user is asked to confirm before any
+        change is made, unless -y was passed on the command line.
+        """
+        self.set_datetime()
+        os.makedirs(local_folder, exist_ok=True)
+        self.new_folder(remote_folder)
+        print("Building inventory... ", end="", flush=True)
+        remote_files, remote_folders, local_files, local_folders = (
+            self._mirror_inventory(local_folder, remote_folder)
+        )
+        print("done")
+
+        tolerance = timedelta(seconds=2)
+        to_download = sorted(
+            path
+            for path, rmtime in remote_files.items()
+            if local_files.get(path) is None
+            or abs(rmtime - local_files[path]) > tolerance
+        )
+        to_delete_local = sorted(p for p in local_files if p not in remote_files)
+        folders_to_create_local = sorted(
+            f for f in remote_folders if f not in local_folders
+        )
+        folders_to_delete_local = sorted(
+            (
+                f
+                for f in local_folders
+                if f not in remote_folders and f != remote_folder
+            ),
+            reverse=True,
+        )
+
+        actions = [
+            (to_delete_local, "files DELETED locally"),
+            (folders_to_delete_local, "folders DELETED locally"),
+            (folders_to_create_local, "folders CREATED locally"),
+            (to_download, "files DOWNLOADED from device"),
+        ]
+        proceed = self._confirm_mirror(actions)
+        if not proceed:
+            return
+
+        progress = tqdm(
+            total=sum(len(items) for items, _ in actions),
+            desc="Mirroring",
+            unit="items",
+        )
+        for remote_path in to_delete_local:
+            rel = Path(remote_path).relative_to(remote_folder)
+            local_path = Path(local_folder) / rel
+            if local_path.exists():
+                tqdm.write("X " + str(local_path))
+                os.remove(local_path)
+            progress.update()
+        for remote_path in folders_to_delete_local:
+            rel = Path(remote_path).relative_to(remote_folder)
+            local_path = Path(local_folder) / rel
+            if local_path.exists():
+                tqdm.write("X " + str(local_path))
+                try:
+                    os.rmdir(local_path)
+                except OSError as e:
+                    tqdm.write(
+                        f"WARNING: could not remove folder {local_path}: {e}"
+                    )
+            progress.update()
+        for remote_path in folders_to_create_local:
+            rel = Path(remote_path).relative_to(remote_folder)
+            local_path = Path(local_folder) / rel
+            tqdm.write("+ " + str(local_path))
+            os.makedirs(local_path, exist_ok=True)
+            progress.update()
+        for remote_path in to_download:
+            rel = Path(remote_path).relative_to(remote_folder)
+            local_path = Path(local_folder) / rel
+            tqdm.write("⇣ " + str(remote_path))
+            self.download_file(remote_path, local_path)
+            remote_time_local = (
+                remote_files[remote_path]
+                .replace(tzinfo=timezone.utc)
+                .astimezone(tz=None)
+            )
+            mod_time = time.mktime(remote_time_local.timetuple())
+            os.utime(local_path, (mod_time, mod_time))
+            progress.update()
+        progress.close()
+
+    def force_sync_to_device(self, local_folder, remote_folder="Document"):
+        """
+        One-way mirror: make the device match the local folder.
+
+        Uploads local files whose modification time differs from the device
+        copy and DELETES files and (empty) folders on the device that are
+        not present locally. Only .pdf files are considered, matching
+        `sync`.
+
+        A plan is printed and the user is asked to confirm before any
+        change is made, unless -y was passed on the command line.
+        """
+        self.set_datetime()
+        self.new_folder(remote_folder)
+        print("Building inventory... ", end="", flush=True)
+        remote_files, remote_folders, local_files, local_folders = (
+            self._mirror_inventory(local_folder, remote_folder)
+        )
+        print("done")
+
+        tolerance = timedelta(seconds=2)
+        to_upload = sorted(
+            path
+            for path, lmtime in local_files.items()
+            if remote_files.get(path) is None
+            or abs(lmtime - remote_files[path]) > tolerance
+        )
+        to_delete_remote = sorted(p for p in remote_files if p not in local_files)
+        folders_to_create_remote = sorted(
+            f for f in local_folders if f not in remote_folders
+        )
+        folders_to_delete_remote = sorted(
+            (
+                f
+                for f in remote_folders
+                if f not in local_folders and f != remote_folder
+            ),
+            reverse=True,
+        )
+
+        actions = [
+            (to_delete_remote, "files DELETED on device"),
+            (folders_to_delete_remote, "folders DELETED on device"),
+            (folders_to_create_remote, "folders CREATED on device"),
+            (to_upload, "files UPLOADED to device"),
+        ]
+        proceed = self._confirm_mirror(actions)
+        if not proceed:
+            return
+
+        progress = tqdm(
+            total=sum(len(items) for items, _ in actions),
+            desc="Mirroring",
+            unit="items",
+        )
+        for remote_path in to_delete_remote:
+            if self.path_exists(remote_path):
+                tqdm.write("X " + str(remote_path))
+                self.delete_document(remote_path)
+            progress.update()
+        for remote_path in folders_to_delete_remote:
+            if self.path_exists(remote_path):
+                tqdm.write("X " + str(remote_path))
+                try:
+                    self.delete_folder(remote_path)
+                except Exception as e:
+                    tqdm.write(
+                        f"WARNING: could not remove folder {remote_path}: {e}"
+                    )
+            progress.update()
+        for remote_path in folders_to_create_remote:
+            tqdm.write("+ " + str(remote_path))
+            self.new_folder(remote_path)
+            progress.update()
+        for remote_path in to_upload:
+            rel = Path(remote_path).relative_to(remote_folder)
+            local_path = Path(local_folder) / rel
+            tqdm.write("⇡ " + str(local_path))
+            self.upload_file(local_path, remote_path)
+            progress.update()
+        progress.close()
+
+        # After upload the device stamps its own modified_date, which will
+        # differ from the local mtime and cause the next run to re-upload
+        # the same file. Align local mtimes to the fresh remote timestamps
+        # so subsequent runs stabilize to a no-op.
+        if to_upload:
+            print("Aligning local timestamps... ", end="", flush=True)
+            refreshed = self.traverse_folder(
+                remote_folder,
+                fields=["entry_path", "modified_date", "entry_type"],
+            )
+            by_path = {}
+            for f in refreshed:
+                if f["entry_type"] == "document":
+                    p = unicodedata.normalize("NFC", f["entry_path"]).replace(
+                        os.sep, "/"
+                    )
+                    by_path[p] = f["modified_date"]
+            for remote_path in to_upload:
+                rel = Path(remote_path).relative_to(remote_folder)
+                local_path = Path(local_folder) / rel
+                new_mdate = by_path.get(remote_path)
+                if new_mdate is None:
+                    continue
+                remote_time = datetime.strptime(new_mdate, "%Y-%m-%dT%H:%M:%SZ")
+                remote_time_local = remote_time.replace(
+                    tzinfo=timezone.utc
+                ).astimezone(tz=None)
+                mod_time = time.mktime(remote_time_local.timetuple())
+                try:
+                    os.utime(local_path, (mod_time, mod_time))
+                except OSError:
+                    pass
+            print("done")
 
     def _copy_move_data(self, file_id, folder_id, new_filename=None):
         data = {"parent_folder_id": folder_id}

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -1004,11 +1004,17 @@ class DigitalPaper:
         if total == 0:
             print("Already in sync. Nothing to do.")
             return None
+        preview = 5
         print("")
         print("Planned changes:")
         for items, description in actions:
-            if items:
-                print(f"  {len(items):4d} {description}")
+            if not items:
+                continue
+            print(f"  {len(items):4d} {description}:")
+            for item in items[:preview]:
+                print(f"       {item}")
+            if len(items) > preview:
+                print(f"       ... and {len(items) - preview} more")
         print("")
         if self.assume_yes:
             return True


### PR DESCRIPTION
## Summary
This PR adds two new one-way mirror synchronization commands (`sync-from-device` and `sync-to-device`) to handle workflows where files are reorganized locally or on the device. Unlike the existing `sync` command which attempts bidirectional merging, these commands make one side match the other exactly, including deleting files and empty folders that don't exist on the source.

## Key Changes

- **New core methods in `dptrp1.py`**:
  - `_mirror_inventory()`: Builds normalized inventories of PDF files and folders on both the device and local disk, returning modification times for comparison
  - `_confirm_mirror()`: Displays planned changes and prompts user for confirmation (respects `-y` flag to skip prompt)
  - `force_sync_to_local()`: One-way mirror that downloads changed/new PDFs from device and deletes local files/folders not on device
  - `force_sync_to_device()`: One-way mirror that uploads changed/new PDFs to device and deletes remote files/folders not present locally

- **New CLI commands in `cli/dptrp1.py`**:
  - `do_sync_from_device()`: Wrapper for `force_sync_to_local()`
  - `do_sync_to_device()`: Wrapper for `force_sync_to_device()`
  - Both commands registered in the command dispatch table

- **Documentation in `README.md`**:
  - New section explaining one-way mirror commands and their use cases
  - Example workflow for reorganizing files (pull annotations, reorganize locally, push new layout)
  - Notes on confirmation prompts and the `-y` flag

## Implementation Details

- Uses `timedelta(seconds=2)` tolerance when comparing modification times to account for timestamp precision differences
- Normalizes paths using NFC unicode normalization and forward slashes for consistent comparison
- Only considers `.pdf` files (matching existing `sync` behavior)
- After uploading files, refreshes remote timestamps and aligns local mtimes to prevent re-uploading on next run
- Provides visual feedback with progress bar and symbols (X for delete, + for create, ⇣/⇡ for download/upload)
- Handles edge cases like non-empty folders gracefully with warnings rather than failures
- Added `timedelta` import to support tolerance-based timestamp comparison

https://claude.ai/code/session_01KqeyghshRokxaY7GRbK4rQ